### PR TITLE
Remove 42mb warning

### DIFF
--- a/src/for_django_1-5/myproject/myproject/myapp/forms.py
+++ b/src/for_django_1-5/myproject/myproject/myapp/forms.py
@@ -3,6 +3,5 @@ from django import forms
 
 class DocumentForm(forms.Form):
     docfile = forms.FileField(
-        label='Select a file',
-        help_text='max. 42 megabytes'
+        label='Select a file'
     )


### PR DESCRIPTION
Works fine with a 1.3 GB file using Django 1.5.1 built-in webserver and Chome as browser on Mac, so no need for 42mb warning.
